### PR TITLE
Update dependabot configuration for Go and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "frontend/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request adds initial configuration for Dependabot to automate dependency updates for both Go and JavaScript packages. The configuration sets up weekly update schedules for each ecosystem.

Dependency management automation:

* Added `.github/dependabot.yml` to enable Dependabot version updates for the `gomod` (Go) ecosystem in the root directory and the `npm` (JavaScript) ecosystem in the `frontend/` directory, with both scheduled to update weekly.